### PR TITLE
Remove support for Python 3.7

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,9 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.7, 3.8, 3.9]
+        python-version:
+          - "3.8"
+          - "3.9"
 
     steps:
       - uses: actions/checkout@v2

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Plugins for camacq:
 
 ### Requirements
 
-- Python version 3.7+.
+- Python version 3.8+.
 - camacq >= 0.6.0
 
 ## Usage

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -1,4 +1,3 @@
-asynctest==0.13.0
 pytest==6.2.5
 pytest-asyncio==0.17.1
 pytest-cov==3.0.0

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ setuptools.setup(
     long_description=LONG_DESCRIPTION,
     long_description_content_type="text/markdown",
     packages=setuptools.find_packages(),
-    python_requires=">=3.7",
+    python_requires=">=3.8",
     install_requires=REQUIRES,
     entry_points={
         "camacq.plugins": [
@@ -35,7 +35,6 @@ setuptools.setup(
         "Development Status :: 2 - Pre-Alpha",
         "Programming Language :: Python",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
     ],

--- a/tests/production/test_production.py
+++ b/tests/production/test_production.py
@@ -1,9 +1,8 @@
 """Test the production plugin."""
-from unittest.mock import call
+from unittest.mock import AsyncMock, call
 
 import pytest
 import voluptuous as vol
-from asynctest import CoroutineMock
 from ruamel.yaml import YAML
 
 from camacq import plugins
@@ -78,7 +77,7 @@ async def test_image_events(center, leica_sample):
     well_x = 0
     well_y = 0
     await plugins.setup_module(center, config)
-    calc_gain = CoroutineMock()
+    calc_gain = AsyncMock()
     gains = {
         "green": 800,
         "blue": 700,

--- a/tox.ini
+++ b/tox.ini
@@ -1,11 +1,10 @@
 [tox]
-envlist = py37, py38, py39, lint
+envlist = py38, py39, lint
 skip_missing_interpreters = True
 
 [gh-actions]
 python =
-    3.7: py37, lint
-    3.8: py38
+    3.8: py38, lint
     3.9: py39
 
 [testenv]


### PR DESCRIPTION
- Scientific Python libraries like numpy, that we depend on, have dropped support for Python 3.7.