### PR TITLE
Remove support for Python 3.8 and 3.9

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,8 +15,6 @@ jobs:
     strategy:
       matrix:
         python-version:
-          - "3.8"
-          - "3.9"
           - "3.10"
 
     steps:

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Plugins for camacq:
 
 ### Requirements
 
-- Python version 3.8+.
+- Python version 3.10+.
 - camacq >= 0.6.0
 
 ## Usage

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,5 @@
 """Set up file for camacq-plugins package."""
+
 from pathlib import Path
 
 import setuptools
@@ -23,7 +24,7 @@ setuptools.setup(
     long_description=LONG_DESCRIPTION,
     long_description_content_type="text/markdown",
     packages=setuptools.find_packages(),
-    python_requires=">=3.8",
+    python_requires=">=3.10",
     install_requires=REQUIRES,
     entry_points={
         "camacq.plugins": [
@@ -35,8 +36,6 @@ setuptools.setup(
         "Development Status :: 2 - Pre-Alpha",
         "Programming Language :: Python",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.8",
-        "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
     ],
 )

--- a/tox.ini
+++ b/tox.ini
@@ -1,12 +1,10 @@
 [tox]
-envlist = py38, py39, py310, lint
+envlist = py310, lint
 skip_missing_interpreters = True
 
 [gh-actions]
 python =
-    3.8: py38, lint
-    3.9: py39
-    3.10: py310
+    3.10: py310, lint
 
 [testenv]
 commands =


### PR DESCRIPTION
- Python 3.8 is end of life since October 2024.
- Scientific Python currently only supports Python 3.10 - 3.13.